### PR TITLE
Fix bytes conversion for readability

### DIFF
--- a/newsplease/pipeline/extractor/extractors/readability_extractor.py
+++ b/newsplease/pipeline/extractor/extractors/readability_extractor.py
@@ -22,7 +22,14 @@ class ReadabilityExtractor(AbstractExtractor):
         :return: ArticleCandidate containing the recovered article data.
         """
 
-        doc = Document(deepcopy(item['spider_response'].body))
+        html = deepcopy(
+            getattr(item["spider_response"], "text", item["spider_response"].body)
+        )
+        if isinstance(html, bytes):
+            encoding = getattr(item["spider_response"], "encoding", None) or "utf-8"
+            html = html.decode(encoding, errors="replace")
+
+        doc = Document(html)
         description = doc.summary()
 
         article_candidate = ArticleCandidate()


### PR DESCRIPTION
## Summary
- decode spider HTML bytes before passing to readability

## Testing
- `pip install -e .`

------
https://chatgpt.com/codex/tasks/task_e_686af539014c83319d8338cc5e00a33f